### PR TITLE
Panic message is written to RAM, not flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Bus 003 Device 078: ID 32ac:0021 Framework Laptop 16 B1 Display
 When the Rust code panics, the RP2040 resets itself into bootloader mode.
 This means a new firmware can be written to overwrite the old one.
 
-Additionally the panic message is written to XIP RAM, which can be with [picotool](https://github.com/raspberrypi/picotool):
+Additionally the panic message is written to XIP RAM, which can be read with [picotool](https://github.com/raspberrypi/picotool):
 
 ```sh
 sudo picotool save -r 0x15000000 0x15004000 message.bin

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ Bus 003 Device 078: ID 32ac:0021 Framework Laptop 16 B1 Display
   bcdDevice            0.10
 ```
 
-## Panic
+## Rust Panic
 
-On panic the RP2040 resets itself into bootloader mode.
+When the Rust code panics, the RP2040 resets itself into bootloader mode.
 This means a new firmware can be written to overwrite the old one.
 
-Additionally the panic message is written to flash, which can be read as follows:
+Additionally the panic message is written to XIP RAM, which can be with [picotool](https://github.com/raspberrypi/picotool):
 
 ```sh
 sudo picotool save -r 0x15000000 0x15004000 message.bin


### PR DESCRIPTION
See: https://github.com/jannic/rp2040-panic-usb-boot#panic-messages

Fixes #27 