### PR TITLE
Waveform audio input on `ledmatrix`

### DIFF
--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libudev-dev
+        sudo apt-get install -y libudev-dev libasound2-dev
 
     - name: Setup Rust toolchain
       run: rustup show
@@ -85,7 +85,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libudev-dev
+        sudo apt-get install -y libudev-dev libasound2-dev
 
     - name: Setup Rust toolchain
       run: rustup show

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,7 +2615,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vis-core"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/visualizer2.git#1fe908012a9c156695921f3b6bb47178e1332b92"
+source = "git+https://github.com/Rahix/visualizer2.git?rev=1fe908012a9c156695921f3b6bb47178e1332b92#1fe908012a9c156695921f3b6bb47178e1332b92"
 dependencies = [
  "apodize",
  "color-backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "st7306",
  "tinybmp",
@@ -311,7 +311,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "usb-device",
@@ -887,7 +887,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "st7306",
@@ -1276,7 +1276,7 @@ dependencies = [
  "heapless",
  "is31fl3741",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "usb-device",
  "usbd-hid",
@@ -2092,28 +2092,6 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
-dependencies = [
- "cortex-m",
- "critical-section",
- "embedded-hal",
- "fugit",
- "itertools",
- "nb 1.1.0",
- "paste",
- "pio",
- "rand_core 0.6.4",
- "rp2040-hal-macros",
- "rp2040-pac",
- "usb-device",
- "vcell",
- "void",
-]
-
-[[package]]
-name = "rp2040-hal"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd64ea14218eaa350e5cf1023b7a84c267f092e4a64b69129dc460e53412bed8"
@@ -2160,11 +2138,12 @@ dependencies = [
 
 [[package]]
 name = "rp2040-panic-usb-boot"
-version = "0.3.0"
-source = "git+https://github.com/rwalkr/rp2040-panic-usb-boot#d93e15bd3d618e7c2cc659a9634514db4a14889c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b311d2a72e5a63d5511345b61fe7dd02ce0990bd093ba3dc94b3e80b0a0e373"
 dependencies = [
  "cortex-m",
- "rp2040-hal 0.8.0",
+ "rp2040-hal",
 ]
 
 [[package]]
@@ -2636,7 +2615,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vis-core"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/visualizer2.git#1fe908012a9c156695921f3b6bb47178e1332b92"
+source = "git+https://github.com/Rahix/visualizer2.git?rev=1fe908012a9c156695921f3b6bb47178e1332b92#1fe908012a9c156695921f3b6bb47178e1332b92"
 dependencies = [
  "apodize",
  "color-backtrace",
@@ -2960,16 +2939,16 @@ dependencies = [
 
 [[package]]
 name = "ws2812-pio"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adb47d7fe2fc0590cb0a3d202abc50272105ddd3bebcca68d24d18ef3cab2fb"
+checksum = "7d219e3b43c1e14305b36363060c0348d560314e235d999cf492bbbab1f38e8d"
 dependencies = [
  "cortex-m",
  "embedded-hal",
  "fugit",
  "nb 1.1.0",
  "pio",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "smart-leds-trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "st7306",
  "tinybmp",
@@ -311,7 +311,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "usb-device",
@@ -887,7 +887,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "st7306",
@@ -1276,7 +1276,7 @@ dependencies = [
  "heapless",
  "is31fl3741",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "usb-device",
  "usbd-hid",
@@ -2092,6 +2092,28 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "embedded-hal",
+ "fugit",
+ "itertools",
+ "nb 1.1.0",
+ "paste",
+ "pio",
+ "rand_core 0.6.4",
+ "rp2040-hal-macros",
+ "rp2040-pac",
+ "usb-device",
+ "vcell",
+ "void",
+]
+
+[[package]]
+name = "rp2040-hal"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd64ea14218eaa350e5cf1023b7a84c267f092e4a64b69129dc460e53412bed8"
@@ -2138,12 +2160,11 @@ dependencies = [
 
 [[package]]
 name = "rp2040-panic-usb-boot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b311d2a72e5a63d5511345b61fe7dd02ce0990bd093ba3dc94b3e80b0a0e373"
+version = "0.3.0"
+source = "git+https://github.com/rwalkr/rp2040-panic-usb-boot#d93e15bd3d618e7c2cc659a9634514db4a14889c"
 dependencies = [
  "cortex-m",
- "rp2040-hal",
+ "rp2040-hal 0.8.0",
 ]
 
 [[package]]
@@ -2615,7 +2636,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vis-core"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/visualizer2.git?rev=1fe908012a9c156695921f3b6bb47178e1332b92#1fe908012a9c156695921f3b6bb47178e1332b92"
+source = "git+https://github.com/Rahix/visualizer2.git#1fe908012a9c156695921f3b6bb47178e1332b92"
 dependencies = [
  "apodize",
  "color-backtrace",
@@ -2939,16 +2960,16 @@ dependencies = [
 
 [[package]]
 name = "ws2812-pio"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d219e3b43c1e14305b36363060c0348d560314e235d999cf492bbbab1f38e8d"
+checksum = "3adb47d7fe2fc0590cb0a3d202abc50272105ddd3bebcca68d24d18ef3cab2fb"
 dependencies = [
  "cortex-m",
  "embedded-hal",
  "fugit",
  "nb 1.1.0",
  "pio",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "smart-leds-trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,11 +40,42 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alsa"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8512c9117059663fb5606788fbca3619e2a91dac0e3fe516242eab1fa6be5e44"
+dependencies = [
+ "alsa-sys",
+ "bitflags",
+ "libc",
+ "nix",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -49,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -83,18 +123,24 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "apodize"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca387cdc0a1f9c7a7c26556d584aa2d07fc529843082e4861003cde4ab914ed"
 
 [[package]]
 name = "arrayvec"
@@ -109,6 +155,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -137,7 +203,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "st7306",
  "tinybmp",
@@ -147,12 +213,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.6.2",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
  "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex 1.7.3",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -175,9 +276,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
@@ -192,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "c1minimal"
 version = "0.1.4"
 dependencies = [
@@ -204,7 +311,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "usb-device",
@@ -214,10 +321,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -241,21 +372,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.2.4"
+name = "clang-sys"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
+ "once_cell 1.17.1",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -283,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +441,17 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color-backtrace"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c04463c99389fff045d2b90ce84f5131332712c7ffbede020f5e9ad1ed685"
+dependencies = [
+ "atty",
+ "backtrace",
+ "termcolor",
 ]
 
 [[package]]
@@ -305,10 +467,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb17e2d1795b1996419648915df94bc7103c28f7b48062d7acf4652fc371b2ff"
+dependencies = [
+ "bitflags",
+ "core-foundation-sys 0.6.2",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f034b2258e6c4ade2f73bf87b21047567fb913ee9550837c2316d139b0262b24"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "cortex-m"
@@ -340,6 +538,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d959d90e938c5493000514b446987c07aed46c668faaa7d34d6c7a67b1a578c"
+dependencies = [
+ "alsa",
+ "core-foundation-sys 0.8.4",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.19.0",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "once_cell 1.17.1",
+ "parking_lot 0.12.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.46.0",
 ]
 
 [[package]]
@@ -393,11 +616,11 @@ version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "scopeguard",
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -435,7 +658,7 @@ checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
- "once_cell",
+ "once_cell 1.17.1",
  "proc-macro2",
  "quote",
  "scratch",
@@ -458,6 +681,12 @@ dependencies = [
  "quote",
  "syn 2.0.15",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "debug-helper"
@@ -562,6 +791,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex 1.7.3",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,7 +811,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -580,6 +822,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -594,8 +845,20 @@ dependencies = [
  "lebe",
  "miniz_oxide 0.6.2",
  "rayon-core",
- "smallvec",
+ "smallvec 1.10.0",
  "zune-inflate",
+]
+
+[[package]]
+name = "ezconf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a13b438ef62361572d5693bba58ad3b6304b4245ba5b6d3d7629e8eb92aa897"
+dependencies = [
+ "log",
+ "once_cell 0.1.8",
+ "toml",
+ "toml-query",
 ]
 
 [[package]]
@@ -624,7 +887,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "st7306",
@@ -666,6 +929,12 @@ dependencies = [
  "pin-project",
  "spin",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fugit"
@@ -718,6 +987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "half"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +1015,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heapless"
@@ -756,6 +1043,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -770,17 +1066,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -813,14 +1115,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown",
+]
+
+[[package]]
 name = "inputmodule-control"
 version = "0.1.4"
 dependencies = [
  "chrono",
  "clap",
  "image",
- "rand",
+ "rand 0.8.5",
  "serialport",
+ "vis-core",
 ]
 
 [[package]]
@@ -831,8 +1144,14 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is-match"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5b386aef33a1c677be65237cb9d32c3f3ef56bd035949710c4bb13083eb053"
 
 [[package]]
 name = "is-terminal"
@@ -843,7 +1162,7 @@ dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -865,6 +1184,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1243,18 @@ checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -902,7 +1276,7 @@ dependencies = [
  "heapless",
  "is31fl3741",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "rp2040-panic-usb-boot",
  "usb-device",
  "usbd-hid",
@@ -911,9 +1285,19 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libudev"
@@ -946,9 +1330,18 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+dependencies = [
+ "scopeguard 0.3.3",
+]
 
 [[package]]
 name = "lock_api"
@@ -956,8 +1349,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "autocfg",
- "scopeguard",
+ "autocfg 1.1.0",
+ "scopeguard 1.1.0",
 ]
 
 [[package]]
@@ -988,6 +1381,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,7 +1407,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1007,6 +1415,12 @@ name = "micromath"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4010833aea396656c2f91ee704d51a6f1329ec2ab56ffd00bfd56f7481ea94"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1052,6 +1466,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "ndk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.4.1+23.1.7779620"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1503,16 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1101,7 +1554,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1111,7 +1564,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1122,7 +1575,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -1133,7 +1586,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1161,9 +1614,51 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "oboe"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8868cc237ee02e2d9618539a23a8d228b9bb3fc2e7a5b11eed3831de77c395d0"
+dependencies = [
+ "jni 0.20.0",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f44155e7fb718d3cfddcf70690b2b51ac4412f347cd9e4fbe511abe9cd7b5f2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "once_cell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
+dependencies = [
+ "parking_lot 0.7.1",
 ]
 
 [[package]]
@@ -1173,10 +1668,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+dependencies = [
+ "lock_api 0.1.5",
+ "parking_lot_core 0.4.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api 0.4.9",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+dependencies = [
+ "libc",
+ "rand 0.6.5",
+ "rustc_version 0.2.3",
+ "smallvec 0.6.14",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.10.0",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project"
@@ -1235,6 +1782,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell 1.17.1",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,13 +1853,42 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1303,8 +1898,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1314,6 +1924,74 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
@@ -1338,21 +2016,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.8.1"
+name = "rdrand"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "aho-corasick",
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+dependencies = [
+ "aho-corasick 0.6.10",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.5.6",
+ "thread_local",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick 0.7.20",
+ "memchr",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+dependencies = [
+ "ucd-util",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rgb"
@@ -1374,6 +2092,28 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "embedded-hal",
+ "fugit",
+ "itertools",
+ "nb 1.1.0",
+ "paste",
+ "pio",
+ "rand_core 0.6.4",
+ "rp2040-hal-macros",
+ "rp2040-pac",
+ "usb-device",
+ "vcell",
+ "void",
+]
+
+[[package]]
+name = "rp2040-hal"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd64ea14218eaa350e5cf1023b7a84c267f092e4a64b69129dc460e53412bed8"
@@ -1387,7 +2127,7 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "pio",
- "rand_core",
+ "rand_core 0.6.4",
  "rp2040-hal-macros",
  "rp2040-pac",
  "usb-device",
@@ -1420,13 +2160,24 @@ dependencies = [
 
 [[package]]
 name = "rp2040-panic-usb-boot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b311d2a72e5a63d5511345b61fe7dd02ce0990bd093ba3dc94b3e80b0a0e373"
+version = "0.3.0"
+source = "git+https://github.com/rwalkr/rp2040-panic-usb-boot#d93e15bd3d618e7c2cc659a9634514db4a14889c"
 dependencies = [
  "cortex-m",
- "rp2040-hal",
+ "rp2040-hal 0.8.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1447,18 +2198,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.14"
+name = "rustfft"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "scopeguard"
@@ -1512,15 +2293,30 @@ dependencies = [
  "libudev",
  "mach 0.3.2",
  "nix",
- "regex",
+ "regex 1.7.3",
  "winapi",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
 
 [[package]]
 name = "smallvec"
@@ -1552,7 +2348,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.9",
 ]
 
 [[package]]
@@ -1581,6 +2377,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -1640,6 +2442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "tiff"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +2480,70 @@ checksum = "0e959c507975d768a226a08227d56791f6e60bddcf714ad7ef67ae2d20bae743"
 dependencies = [
  "embedded-graphics",
 ]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml-query"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6854664bfc6df0360c695480836ee90e2d0c965f06db291d10be9344792d43e8"
+dependencies = [
+ "error-chain",
+ "is-match",
+ "lazy_static",
+ "regex 0.2.11",
+ "toml",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88de9e10c067f441831d00cca341cf66fc69227ac6962292f944382dd61dacb9"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "unicode-ident"
@@ -1735,6 +2610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +2634,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vis-core"
+version = "0.1.0"
+source = "git+https://github.com/Rahix/visualizer2.git#1fe908012a9c156695921f3b6bb47178e1332b92"
+dependencies = [
+ "apodize",
+ "color-backtrace",
+ "cpal",
+ "env_logger",
+ "ezconf",
+ "log",
+ "parking_lot 0.12.1",
+ "rustfft",
+ "triple_buffer",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +2662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1797,11 +2704,23 @@ checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
+ "once_cell 1.17.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1832,6 +2751,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "weezl"
@@ -1872,11 +2801,29 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -1885,7 +2832,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1894,14 +2856,20 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1911,9 +2879,21 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1923,9 +2903,21 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1935,9 +2927,21 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1946,17 +2950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "ws2812-pio"
-version = "0.6.0"
+name = "winnow"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d219e3b43c1e14305b36363060c0348d560314e235d999cf492bbbab1f38e8d"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ws2812-pio"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3adb47d7fe2fc0590cb0a3d202abc50272105ddd3bebcca68d24d18ef3cab2fb"
 dependencies = [
  "cortex-m",
  "embedded-hal",
  "fugit",
  "nb 1.1.0",
  "pio",
- "rp2040-hal",
+ "rp2040-hal 0.7.0",
  "smart-leds-trait",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "st7306",
  "tinybmp",
@@ -311,7 +311,7 @@ dependencies = [
  "fugit",
  "heapless",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "usb-device",
@@ -887,7 +887,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "smart-leds",
  "st7306",
@@ -1276,7 +1276,7 @@ dependencies = [
  "heapless",
  "is31fl3741",
  "rp2040-boot2",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "rp2040-panic-usb-boot",
  "usb-device",
  "usbd-hid",
@@ -2092,28 +2092,6 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
-dependencies = [
- "cortex-m",
- "critical-section",
- "embedded-hal",
- "fugit",
- "itertools",
- "nb 1.1.0",
- "paste",
- "pio",
- "rand_core 0.6.4",
- "rp2040-hal-macros",
- "rp2040-pac",
- "usb-device",
- "vcell",
- "void",
-]
-
-[[package]]
-name = "rp2040-hal"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd64ea14218eaa350e5cf1023b7a84c267f092e4a64b69129dc460e53412bed8"
@@ -2160,11 +2138,12 @@ dependencies = [
 
 [[package]]
 name = "rp2040-panic-usb-boot"
-version = "0.3.0"
-source = "git+https://github.com/rwalkr/rp2040-panic-usb-boot#d93e15bd3d618e7c2cc659a9634514db4a14889c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b311d2a72e5a63d5511345b61fe7dd02ce0990bd093ba3dc94b3e80b0a0e373"
 dependencies = [
  "cortex-m",
- "rp2040-hal 0.8.0",
+ "rp2040-hal",
 ]
 
 [[package]]
@@ -2960,16 +2939,16 @@ dependencies = [
 
 [[package]]
 name = "ws2812-pio"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adb47d7fe2fc0590cb0a3d202abc50272105ddd3bebcca68d24d18ef3cab2fb"
+checksum = "7d219e3b43c1e14305b36363060c0348d560314e235d999cf492bbbab1f38e8d"
 dependencies = [
  "cortex-m",
  "embedded-hal",
  "fugit",
  "nb 1.1.0",
  "pio",
- "rp2040-hal 0.7.0",
+ "rp2040-hal",
  "smart-leds-trait",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,13 @@ overflow-checks = true
 
 # cargo build/run --release
 [profile.release]
+codegen-units = 1
 debug = 2
-incremental = true
-lto = 'thin'
-opt-level = 0
-split-debuginfo = "packed"
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 3
+overflow-checks = false
 
 # do not optimize proc-macro crates = faster builds from scratch
 [profile.dev.build-override]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,11 @@ overflow-checks = true
 
 # cargo build/run --release
 [profile.release]
-codegen-units = 1
 debug = 2
-debug-assertions = false
-incremental = false
-lto = 'fat'
-opt-level = 3
-overflow-checks = false
+incremental = true
+lto = 'thin'
+opt-level = 0
+split-debuginfo = "packed"
 
 # do not optimize proc-macro crates = faster builds from scratch
 [profile.dev.build-override]

--- a/fl16-inputmodules/src/control.rs
+++ b/fl16-inputmodules/src/control.rs
@@ -1,3 +1,4 @@
+//! Firmware API - Commands
 use num::FromPrimitive;
 use rp2040_hal::rom_data::reset_to_usb_boot;
 
@@ -40,6 +41,7 @@ use smart_leds::{SmartLedsWrite, RGB8};
 
 #[repr(u8)]
 #[derive(num_derive::FromPrimitive)]
+/// All available commands
 pub enum CommandVals {
     Brightness = 0x00,
     Pattern = 0x01,

--- a/fl16-inputmodules/src/patterns.rs
+++ b/fl16-inputmodules/src/patterns.rs
@@ -272,7 +272,7 @@ pub fn _fill_grid(grid: &Grid, matrix: &mut Foo) {
 
 /// Just sends two I2C commands for the entire grid
 pub fn fill_grid_pixels(grid: &Grid, matrix: &mut Foo) {
-    // B4 LEDs on the first page, 0xAB on the second page
+    // 0xB4 LEDs on the first page, 0xAB on the second page
     let mut brightnesses = [0x00; 0xB4 + 0xAB];
     for y in 0..HEIGHT {
         for x in 0..WIDTH {

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -8,11 +8,11 @@ clap = { version = "4.0", features = ["derive"] }
 serialport = "4.2.0"
 
 # For ledmatrix
+chrono = "0.4.23"
 image = "0.24.5"
 rand = "0.8.5"
-chrono = "0.4.23"
 
 # For audio visualizations
-vis-core = {git = 'https://github.com/Rahix/visualizer2.git', rev = '1fe908012a9c156695921f3b6bb47178e1332b92', optional = true}
+vis-core = { git = 'https://github.com/Rahix/visualizer2.git', rev = '1fe908012a9c156695921f3b6bb47178e1332b92', optional = true }
 [features]
 audio-visualizations = ["vis-core"]

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -15,4 +15,4 @@ image = { version = "0.24.5", default-features = false, features = [
 rand = "0.8.5"
 chrono = "0.4.23"
 
-vis-core = { git = "https://github.com/Rahix/visualizer2.git" }
+vis-core = { git = "https://github.com/Rahix/visualizer2.git", rev = '1fe908012a9c156695921f3b6bb47178e1332b92' }

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -11,3 +11,5 @@ serialport = "4.2.0"
 image = "0.24.5"
 rand = "0.8.5"
 chrono = "0.4.23"
+
+vis-core = { git = "https://github.com/Rahix/visualizer2.git" }

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -8,7 +8,10 @@ clap = { version = "4.0", features = ["derive"] }
 serialport = "4.2.0"
 
 # For ledmatrix
-image = "0.24.5"
+image = { version = "0.24.5", default-features = false, features = [
+    "ico",
+    "gif",
+] }
 rand = "0.8.5"
 chrono = "0.4.23"
 

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -8,10 +8,7 @@ clap = { version = "4.0", features = ["derive"] }
 serialport = "4.2.0"
 
 # For ledmatrix
-image = { version = "0.24.5", default-features = false, features = [
-    "ico",
-    "gif",
-] }
+image = "0.24.5"
 rand = "0.8.5"
 chrono = "0.4.23"
 

--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -12,4 +12,7 @@ image = "0.24.5"
 rand = "0.8.5"
 chrono = "0.4.23"
 
-vis-core = { git = "https://github.com/Rahix/visualizer2.git", rev = '1fe908012a9c156695921f3b6bb47178e1332b92' }
+# For audio visualizations
+vis-core = {git = 'https://github.com/Rahix/visualizer2.git', rev = '1fe908012a9c156695921f3b6bb47178e1332b92', optional = true}
+[features]
+audio-visualizations = ["vis-core"]

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -681,11 +681,8 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
         move |info, samples| {
             analyzer.analyze(samples);
 
-            let sampled_volume = samples.volume(0.3) * 400.0;
-            let display_max_width = 34.0;
-
             info.spectrum.fill_from(&analyzer.average());
-            info.volume = if sampled_volume < 34.0 { sampled_volume } else { display_max_width};
+            info.volume = samples.volume(0.3) * 400.0;
             info.beat = info.spectrum.slice(50.0, 100.0).max() * 0.01;
             info
         },
@@ -697,14 +694,26 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
         // This is just a primitive example, your vis core belongs here
 
         frame.info(|info| {
+
+            let sampled_volume = info.volume;
+            let limited_volume = if sampled_volume < 34.0 { sampled_volume } else { 34.0 };
+
+            let display_max_widths = [10.0, 14.0, 20.0, 28.0, 34.0, 28.0, 20.0, 14.0, 10.0];
+
+            let volumes_to_display = display_max_widths.iter().map(|x| {
+                let computed_width = (limited_volume / 34.0) * x;
+                let next_lowest_odd = computed_width - (computed_width % 2.0) - 1.0;
+                next_lowest_odd as u8
+            }).collect::<Vec<_>>();
+
             for serialdev in serialdevs {
                 eq_cmd(
                     serialdev,
-                    &[info.volume as u8; 9]
+                    volumes_to_display.as_slice()
                 )
             }
         });
-        thread::sleep(Duration::from_millis(15));
+        thread::sleep(Duration::from_millis(30));
     }
 }
 

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -242,6 +242,7 @@ pub fn serial_commands(args: &crate::ClapCli) {
                 random_eq_cmd(&serialdevs);
             }
 
+            #[cfg(feature = "audio-visualizations")]
             if ledmatrix_args.input_eq {
                 input_eq_cmd(&serialdevs);
             }
@@ -640,6 +641,7 @@ fn random_eq_cmd(serialdevs: &Vec<String>) {
     }
 }
 
+#[cfg(feature = "audio-visualizations")]
 /// The data-type for storing analyzer results
 #[derive(Debug, Clone)]
 pub struct AnalyzerResult {
@@ -648,6 +650,7 @@ pub struct AnalyzerResult {
     beat: f32,
 }
 
+#[cfg(feature = "audio-visualizations")]
 // Equalizer-like animation that expands as volume goes up and retracts as it goes down
 fn input_eq_cmd(serialdevs: &Vec<String>) {
     // Example from https://github.com/Rahix/visualizer2/blob/canon/README.md

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -18,6 +18,8 @@ pub const FRAMEWORK_VID: u16 = 0x32AC;
 pub const LED_MATRIX_PID: u16 = 0x0020;
 pub const B1_LCD_PID: u16 = 0x0021;
 
+type Brightness = u8;
+
 // TODO: Use a shared enum with the firmware code
 #[derive(Clone, Copy)]
 #[repr(u8)]
@@ -722,7 +724,7 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
 /// TODO: Implement a commandline parameter for this
 fn eq_cmd(serialdev: &str, vals: &[u8]) {
     assert!(vals.len() <= WIDTH);
-    let mut matrix: [[u8; 34]; 9] = [[0; 34]; 9];
+    let mut matrix: [[Brightness; 34]; 9] = [[0; 34]; 9];
 
     for (col, val) in vals[..9].iter().enumerate() {
         let row: usize = 34 / 2;
@@ -730,10 +732,10 @@ fn eq_cmd(serialdev: &str, vals: &[u8]) {
         let below = (*val as usize) - above;
 
         for i in 0..above {
-            matrix[col][row + i] = 0xFF;
+            matrix[col][row + i] = 0xFF; // Set this LED to full brightness
         }
         for i in 0..below {
-            matrix[col][row - 1 - i] = 0xFF;
+            matrix[col][row - 1 - i] = 0xFF; // Set this LED to full brightness
         }
     }
 
@@ -743,6 +745,8 @@ fn eq_cmd(serialdev: &str, vals: &[u8]) {
 /// Show a black/white matrix
 /// Send everything in a single command
 fn render_matrix(serialdev: &str, matrix: &[[u8; 34]; 9]) {
+    // One bit for each LED, on or off
+    // 39 = ceil(34 * 9 / 8)
     let mut vals: [u8; 39] = [0x00; 39];
 
     for x in 0..9 {

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -640,7 +640,6 @@ fn random_eq_cmd(serialdevs: &Vec<String>) {
     }
 }
 
-
 /// The data-type for storing analyzer results
 #[derive(Debug, Clone)]
 pub struct AnalyzerResult {
@@ -695,11 +694,7 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
 
         frame.info(|info| {
             let sampled_volume = info.volume;
-            let limited_volume = if sampled_volume < 34.0 {
-                sampled_volume
-            } else {
-                34.0
-            };
+            let limited_volume = sampled_volume.min(34.0);
 
             let display_max_widths = [10.0, 14.0, 20.0, 28.0, 34.0, 28.0, 20.0, 14.0, 10.0];
 

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -242,6 +242,10 @@ pub fn serial_commands(args: &crate::ClapCli) {
                 random_eq_cmd(&serialdevs);
             }
 
+            if ledmatrix_args.input_eq {
+                input_eq_cmd(&serialdevs);
+            }
+
             if ledmatrix_args.clock {
                 clock_cmd(&serialdevs);
             }
@@ -633,6 +637,81 @@ fn random_eq_cmd(serialdevs: &Vec<String>) {
             eq_cmd(serialdev, vals.as_slice());
         }
         thread::sleep(Duration::from_millis(200));
+    }
+}
+
+
+// The data-type for storing analyzer results
+#[derive(Debug, Clone)]
+pub struct AnalyzerResult {
+    spectrum: vis_core::analyzer::Spectrum<Vec<f32>>,
+    volume: f32,
+    beat: f32,
+}
+
+// Equalizer-like animation that expands as volume goes up and retracts as it goes down
+fn input_eq_cmd(serialdevs: &Vec<String>) {
+    // Example from https://github.com/Rahix/visualizer2/blob/canon/README.md
+
+    // Initialize the logger.  Take a look at the sources if you want to customize
+    // the logger.
+    vis_core::default_log();
+
+    // Load the default config source.  More about config later on.  You can also
+    // do this manually if you have special requirements.
+    vis_core::default_config();
+
+    // Initialize some analyzer-tools.  These will be moved into the analyzer closure
+    // later on.
+    let mut analyzer = vis_core::analyzer::FourierBuilder::new()
+        .length(512)
+        .window(vis_core::analyzer::window::nuttall)
+        .plan();
+
+    let spectrum = vis_core::analyzer::Spectrum::new(vec![0.0; analyzer.buckets()], 0.0, 1.0);
+
+    let mut frames = vis_core::Visualizer::new(
+        AnalyzerResult {
+            spectrum,
+            volume: 0.0,
+            beat: 0.0,
+        },
+        // This closure is the "analyzer".  It will be executed in a loop to always
+        // have the latest data available.
+        move |info, samples| {
+            analyzer.analyze(samples);
+
+            info.spectrum.fill_from(&analyzer.average());
+            info.volume = samples.volume(0.3) * 400.0;
+            info.beat = info.spectrum.slice(50.0, 100.0).max() * 0.01;
+            info
+        },
+    )
+    // Build the frame iterator which is the base of your loop later on
+    .frames();
+
+    for frame in frames.iter() {
+        // This is just a primitive example, your vis core belongs here
+
+        frame.info(|info| {
+            for serialdev in serialdevs {
+                eq_cmd(
+                    serialdev,
+                    &[
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                    ],
+                )
+            }
+        });
+        thread::sleep(Duration::from_millis(30));
     }
 }
 

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -621,22 +621,80 @@ fn display_gray_image_cmd(serialdev: &str, image_path: &str) {
     commit_cols(&mut port);
 }
 
+// The data-type for storing analyzer results
+#[derive(Debug, Clone)]
+pub struct AnalyzerResult {
+    spectrum: vis_core::analyzer::Spectrum<Vec<f32>>,
+    volume: f32,
+    beat: f32,
+}
+
 /// Display an equlizer looking animation with random values.
 fn random_eq_cmd(serialdevs: &Vec<String>) {
-    loop {
-        // Lower values more likely, makes it look nicer
-        //weights = [i*i for i in range(33, 0, -1)]
-        let population: Vec<u8> = (1..34).collect();
-        let mut rng = thread_rng();
-        let vals = population
-            .choose_multiple_weighted(&mut rng, 9, |item| (34 - item) ^ 2)
-            .unwrap()
-            .copied()
-            .collect::<Vec<_>>();
-        for serialdev in serialdevs {
-            eq_cmd(serialdev, vals.as_slice());
-        }
-        thread::sleep(Duration::from_millis(200));
+    // Example from https://github.com/Rahix/visualizer2/blob/canon/README.md
+
+    // Initialize the logger.  Take a look at the sources if you want to customize
+    // the logger.
+    vis_core::default_log();
+
+    // Load the default config source.  More about config later on.  You can also
+    // do this manually if you have special requirements.
+    vis_core::default_config();
+
+    // Initialize some analyzer-tools.  These will be moved into the analyzer closure
+    // later on.
+    let mut analyzer = vis_core::analyzer::FourierBuilder::new()
+        .length(512)
+        .window(vis_core::analyzer::window::nuttall)
+        .plan();
+
+    let spectrum = vis_core::analyzer::Spectrum::new(vec![0.0; analyzer.buckets()], 0.0, 1.0);
+
+    let mut frames = vis_core::Visualizer::new(
+        AnalyzerResult {
+            spectrum,
+            volume: 0.0,
+            beat: 0.0,
+        },
+        // This closure is the "analyzer".  It will be executed in a loop to always
+        // have the latest data available.
+        move |info, samples| {
+            analyzer.analyze(samples);
+
+            info.spectrum.fill_from(&analyzer.average());
+            info.volume = samples.volume(0.3) * 400.0;
+            info.beat = info.spectrum.slice(50.0, 100.0).max() * 0.01;
+            info
+        },
+    )
+    // Build the frame iterator which is the base of your loop later on
+    .frames();
+
+    for frame in frames.iter() {
+        // This is just a primitive example, your vis core belongs here
+
+        frame.info(|info| {
+            // for n in 0..info.volume as usize {
+            //     print!("{}",n);
+            // }
+            for serialdev in serialdevs {
+                eq_cmd(
+                    serialdev,
+                    &[
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                        info.volume as u8,
+                    ],
+                )
+            }
+        });
+        thread::sleep(Duration::from_millis(30));
     }
 }
 

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -640,7 +640,6 @@ fn random_eq_cmd(serialdevs: &Vec<String>) {
     }
 }
 
-
 // The data-type for storing analyzer results
 #[derive(Debug, Clone)]
 pub struct AnalyzerResult {
@@ -694,23 +693,26 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
         // This is just a primitive example, your vis core belongs here
 
         frame.info(|info| {
-
             let sampled_volume = info.volume;
-            let limited_volume = if sampled_volume < 34.0 { sampled_volume } else { 34.0 };
+            let limited_volume = if sampled_volume < 34.0 {
+                sampled_volume
+            } else {
+                34.0
+            };
 
             let display_max_widths = [10.0, 14.0, 20.0, 28.0, 34.0, 28.0, 20.0, 14.0, 10.0];
 
-            let volumes_to_display = display_max_widths.iter().map(|x| {
-                let computed_width = (limited_volume / 34.0) * x;
-                let next_lowest_odd = computed_width - (computed_width % 2.0) - 1.0;
-                next_lowest_odd as u8
-            }).collect::<Vec<_>>();
+            let volumes_to_display = display_max_widths
+                .iter()
+                .map(|x| {
+                    let computed_width = (limited_volume / 34.0) * x;
+                    let next_lowest_odd = computed_width - (computed_width % 2.0) - 1.0;
+                    next_lowest_odd as u8
+                })
+                .collect::<Vec<_>>();
 
             for serialdev in serialdevs {
-                eq_cmd(
-                    serialdev,
-                    volumes_to_display.as_slice()
-                )
+                eq_cmd(serialdev, volumes_to_display.as_slice())
             }
         });
         thread::sleep(Duration::from_millis(30));

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -681,8 +681,11 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
         move |info, samples| {
             analyzer.analyze(samples);
 
+            let sampled_volume = samples.volume(0.3) * 400.0;
+            let display_max_width = 34.0;
+
             info.spectrum.fill_from(&analyzer.average());
-            info.volume = samples.volume(0.3) * 400.0;
+            info.volume = if sampled_volume < 34.0 { sampled_volume } else { display_max_width};
             info.beat = info.spectrum.slice(50.0, 100.0).max() * 0.01;
             info
         },
@@ -697,21 +700,11 @@ fn input_eq_cmd(serialdevs: &Vec<String>) {
             for serialdev in serialdevs {
                 eq_cmd(
                     serialdev,
-                    &[
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                    ],
+                    &[info.volume as u8; 9]
                 )
             }
         });
-        thread::sleep(Duration::from_millis(30));
+        thread::sleep(Duration::from_millis(15));
     }
 }
 

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -5,7 +5,6 @@ use chrono::Local;
 use image::codecs::gif::GifDecoder;
 use image::{io::Reader as ImageReader, Luma};
 use image::{AnimationDecoder, DynamicImage, ImageBuffer};
-use rand::prelude::*;
 use serialport::{SerialPort, SerialPortInfo, SerialPortType};
 
 use crate::b1display::{B1Pattern, Fps, PowerMode};
@@ -621,7 +620,7 @@ fn display_gray_image_cmd(serialdev: &str, image_path: &str) {
     commit_cols(&mut port);
 }
 
-// The data-type for storing analyzer results
+/// The data-type for storing analyzer results
 #[derive(Debug, Clone)]
 pub struct AnalyzerResult {
     spectrum: vis_core::analyzer::Spectrum<Vec<f32>>,
@@ -696,14 +695,6 @@ fn random_eq_cmd(serialdevs: &Vec<String>) {
         });
         thread::sleep(Duration::from_millis(30));
     }
-}
-
-// The data-type for storing analyzer results
-#[derive(Debug, Clone)]
-pub struct AnalyzerResult {
-    spectrum: vis_core::analyzer::Spectrum<Vec<f32>>,
-    volume: f32,
-    beat: f32,
 }
 
 // Equalizer-like animation that expands as volume goes up and retracts as it goes down

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -5,6 +5,7 @@ use chrono::Local;
 use image::codecs::gif::GifDecoder;
 use image::{io::Reader as ImageReader, Luma};
 use image::{AnimationDecoder, DynamicImage, ImageBuffer};
+use rand::prelude::*;
 use serialport::{SerialPort, SerialPortInfo, SerialPortType};
 
 use crate::b1display::{B1Pattern, Fps, PowerMode};
@@ -620,81 +621,32 @@ fn display_gray_image_cmd(serialdev: &str, image_path: &str) {
     commit_cols(&mut port);
 }
 
+/// Display an equlizer looking animation with random values.
+fn random_eq_cmd(serialdevs: &Vec<String>) {
+    loop {
+        // Lower values more likely, makes it look nicer
+        //weights = [i*i for i in range(33, 0, -1)]
+        let population: Vec<u8> = (1..34).collect();
+        let mut rng = thread_rng();
+        let vals = population
+            .choose_multiple_weighted(&mut rng, 9, |item| (34 - item) ^ 2)
+            .unwrap()
+            .copied()
+            .collect::<Vec<_>>();
+        for serialdev in serialdevs {
+            eq_cmd(serialdev, vals.as_slice());
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+}
+
+
 /// The data-type for storing analyzer results
 #[derive(Debug, Clone)]
 pub struct AnalyzerResult {
     spectrum: vis_core::analyzer::Spectrum<Vec<f32>>,
     volume: f32,
     beat: f32,
-}
-
-/// Display an equlizer looking animation with random values.
-fn random_eq_cmd(serialdevs: &Vec<String>) {
-    // Example from https://github.com/Rahix/visualizer2/blob/canon/README.md
-
-    // Initialize the logger.  Take a look at the sources if you want to customize
-    // the logger.
-    vis_core::default_log();
-
-    // Load the default config source.  More about config later on.  You can also
-    // do this manually if you have special requirements.
-    vis_core::default_config();
-
-    // Initialize some analyzer-tools.  These will be moved into the analyzer closure
-    // later on.
-    let mut analyzer = vis_core::analyzer::FourierBuilder::new()
-        .length(512)
-        .window(vis_core::analyzer::window::nuttall)
-        .plan();
-
-    let spectrum = vis_core::analyzer::Spectrum::new(vec![0.0; analyzer.buckets()], 0.0, 1.0);
-
-    let mut frames = vis_core::Visualizer::new(
-        AnalyzerResult {
-            spectrum,
-            volume: 0.0,
-            beat: 0.0,
-        },
-        // This closure is the "analyzer".  It will be executed in a loop to always
-        // have the latest data available.
-        move |info, samples| {
-            analyzer.analyze(samples);
-
-            info.spectrum.fill_from(&analyzer.average());
-            info.volume = samples.volume(0.3) * 400.0;
-            info.beat = info.spectrum.slice(50.0, 100.0).max() * 0.01;
-            info
-        },
-    )
-    // Build the frame iterator which is the base of your loop later on
-    .frames();
-
-    for frame in frames.iter() {
-        // This is just a primitive example, your vis core belongs here
-
-        frame.info(|info| {
-            // for n in 0..info.volume as usize {
-            //     print!("{}",n);
-            // }
-            for serialdev in serialdevs {
-                eq_cmd(
-                    serialdev,
-                    &[
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                        info.volume as u8,
-                    ],
-                )
-            }
-        });
-        thread::sleep(Duration::from_millis(30));
-    }
 }
 
 // Equalizer-like animation that expands as volume goes up and retracts as it goes down

--- a/inputmodule-control/src/ledmatrix.rs
+++ b/inputmodule-control/src/ledmatrix.rs
@@ -87,6 +87,7 @@ pub struct LedMatrixSubcommand {
     pub random_eq: bool,
 
     /// Display EQ of microphone input
+    #[cfg(feature = "audio-visualizations")]
     #[arg(long)]
     pub input_eq: bool,
 

--- a/inputmodule-control/src/ledmatrix.rs
+++ b/inputmodule-control/src/ledmatrix.rs
@@ -86,6 +86,10 @@ pub struct LedMatrixSubcommand {
     #[arg(long)]
     pub random_eq: bool,
 
+    /// Input EQ
+    #[arg(long)]
+    pub input_eq: bool,
+
     /// EQ with custom values
     #[arg(long, num_args(9))]
     pub eq: Option<Vec<u8>>,

--- a/inputmodule-control/src/ledmatrix.rs
+++ b/inputmodule-control/src/ledmatrix.rs
@@ -86,7 +86,7 @@ pub struct LedMatrixSubcommand {
     #[arg(long)]
     pub random_eq: bool,
 
-    /// Input EQ
+    /// Display EQ of microphone input
     #[arg(long)]
     pub input_eq: bool,
 

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -119,7 +119,7 @@ inputmodule-control led-matrix --eq 1 2 3 4 5 4 3 2 1
 
 ###### Input equalizer
 
-This command generates an equalizer-like visualization of the current audio input.
+This command generates an equalizer-like visualization of the current audio input (microphone).
 It supports most platforms - for details, see [documentation of the cpal crate](https://github.com/RustAudio/cpal).
 
 You must compile the `inputmodule-control` binary with the `audio-visualization` feature on:

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -119,7 +119,8 @@ inputmodule-control led-matrix --eq 1 2 3 4 5 4 3 2 1
 
 ###### Input equalizer
 
-This command generates an equalizer-like visualization of the current audio input. It has only been tested on Linux-based systems running `alsa` or equivalent.
+This command generates an equalizer-like visualization of the current audio input.
+It supports most platforms - for details, see [documentation of the cpal crate](https://github.com/RustAudio/cpal).
 
 You must compile the `inputmodule-control` binary with the `audio-visualization` feature on:
 `cargo build --features audio-visualizations --target x86_64-unknown-linux-gnu -p inputmodule-control`

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -122,7 +122,7 @@ inputmodule-control led-matrix --eq 1 2 3 4 5 4 3 2 1
 This command generates an equalizer-like visualization of the current audio input. It has only been tested on Linux-based systems running `alsa` or equivalent.
 
 You must compile the `inputmodule-control` binary with the `audio-visualization` feature on:
-`cargo clean && cargo build --features audio-visualizations --target x86_64-unknown-linux-gnu -p inputmodule-control`
+`cargo build --features audio-visualizations --target x86_64-unknown-linux-gnu -p inputmodule-control`
 
 Once compiled, you can use the `--input-eq` arg to try the visualizer:
 ```sh

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -117,6 +117,18 @@ inputmodule-control led-matrix --random-eq
 inputmodule-control led-matrix --eq 1 2 3 4 5 4 3 2 1
 ```
 
+###### Input equalizer
+
+This command generates an equalizer-like visualization of the current audio input. It has only been tested on Linux-based systems running `alsa` or equivalent.
+
+You must compile the `inputmodule-control` binary with the `audio-visualization` feature on:
+`cargo clean && cargo build --features audio-visualizations --target x86_64-unknown-linux-gnu -p inputmodule-control`
+
+Once compiled, you can use the `--input-eq` arg to try the visualizer:
+```sh
+inputmodule-control led-matrix --input-eq
+```
+
 ###### Custom string
 
 Display a custom string of up to 5 characters.


### PR DESCRIPTION
Trying to work with an example at https://github.com/Rahix/visualizer2/blob/canon/README.md and @JohnAZoidberg 's boilerplate `eq` module code to get the `ledmatrix` to show a rough waveform of actual current audio input!

Got it working at this point. This is just grabbing the audio input stream with some Rust wrappers for it `cpal` https://github.com/RustAudio/cpal and https://github.com/diwic/alsa-rs to access the underlying `alsa` layer at the system level.

Demo:
https://photos.app.goo.gl/C6NMsZdKnLAnXpwW9

## Testing Instructions

`cargo run --target x86_64-unknown-linux-gnu -p inputmodule-control led-matrix --input-eq`

Then make some noise, assuming your microphone/input is on - try clapping, singing, putting on some music decently loudly, etc!

## Next on the to-do list:
- [x] Troubleshoot the `len is 34 but the index is 34` error (probably a relatively simple one to solve with how I'm constructing the `vec`)
- [x] Clean up the repeated `info.volume as u8` code. I tried using `vec![info.volume as u8; 8]` but I kept getting an array index out of bounds error too
- [x] Make the visualization more interesting. Right now I'm just showing the volume bar on each LED row, I should try to show a smaller one as you get farther away from the center at least.
- [ ] Try to show an actual waveform, somehow, something closer to this https://www.google.com/search?q=waveform+on+an+led+display&tbm=isch&ved=2ahUKEwjWy_2kxbf-AhXRN1kFHR5KD3wQ2-cCegQIABAA&oq=waveform+on+an+led+display&gs_lcp=CgNpbWcQAzoECCMQJzoFCAAQgAQ6BwgAEBgQgARQ4QJYqBdgphhoAXAAeACAAZwEiAGZDZIBCDE0LjEuNS0xmAEAoAEBqgELZ3dzLXdpei1pbWfAAQE&sclient=img&ei=qLRAZNbXG9Hv5NoPnpS94Ac&bih=1079&biw=1918&hl=en or what you'd see on a DJ console/program https://www.google.com/search?tbm=isch&hl=en&source=hp&biw=1918&bih=1079&q=dj+program+waveform&btnG=Search+Images&gbv=2&oq=wmc+miami&gs_l=img.3..0l3j0i24l7.2490l3403l0l3554l9l9l0l2l2l0l50l117l3l3l0.frgbld.