### PR TITLE
windows: Statically link vcruntime DLL

### DIFF
--- a/inputmodule-control/Cargo.toml
+++ b/inputmodule-control/Cargo.toml
@@ -20,3 +20,6 @@ rand = "0.8.5"
 vis-core = { git = 'https://github.com/Rahix/visualizer2.git', rev = '1fe908012a9c156695921f3b6bb47178e1332b92', optional = true }
 [features]
 audio-visualizations = ["vis-core"]
+
+[build-dependencies]
+static_vcruntime = "2.0"

--- a/inputmodule-control/build.rs
+++ b/inputmodule-control/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    static_vcruntime::metabuild();
+}


### PR DESCRIPTION
Otherwise it won't run on some freshly installed machines. Windows complains that `vcruntime140.dll` is missing. Users would have to install the MSVC C++ Redistributable package.

This is the same fix as in FrameworkComputer/qmk_hid#10. The measurements of that binary are:
On a local build of `cargo clean; cargo build --release`: Size of .exe before: 857 KB
Size of .exe after: 878 KB

Note: Only affects release builds! I think that's because the debug version of this DLL isn't redistributable.