### PR TITLE
gh-actions: Build in release mode

### DIFF
--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -44,16 +44,16 @@ jobs:
       run: rustup show
 
     - name: Build Linux tool
-      run: cargo build --target x86_64-unknown-linux-gnu -p inputmodule-control
+      run: cargo build --release --target x86_64-unknown-linux-gnu -p inputmodule-control
 
     - name: Check if Linux tool can start
-      run: cargo run --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help
+      run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help
 
     - name: Upload Linux tool
       uses: actions/upload-artifact@v3
       with:
         name: inputmodule-control
-        path: target/x86_64-unknown-linux-gnu/debug/inputmodule-control
+        path: target/x86_64-unknown-linux-gnu/release/inputmodule-control
 
   build-windows:
     name: Build Windows
@@ -65,16 +65,16 @@ jobs:
       run: rustup show
 
     - name: Build Windows tool
-      run: cargo build --target x86_64-pc-windows-msvc -p inputmodule-control
+      run: cargo build --release --target x86_64-pc-windows-msvc -p inputmodule-control
 
     - name: Check if Windows tool can start
-      run: cargo run --target x86_64-pc-windows-msvc -p inputmodule-control -- --help
+      run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help
 
     - name: Upload Windows App
       uses: actions/upload-artifact@v3
       with:
         name: inputmodule-control.exe
-        path: target/x86_64-pc-windows-msvc/debug/inputmodule-control.exe
+        path: target/x86_64-pc-windows-msvc/release/inputmodule-control.exe
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "image",
  "rand 0.8.5",
  "serialport",
+ "static_vcruntime",
  "vis-core",
 ]
 
@@ -2090,6 +2091,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_vcruntime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
 
 [[package]]
 name = "strength_reduce"


### PR DESCRIPTION
Better performance. And for windows we need it to statically link vcruntime140.dll