### PR TITLE
Use cargo-make to build the packages

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -65,8 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
       - name: Setup Rust toolchain
         run: rustup show
@@ -93,8 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
       - name: Setup Rust toolchain
         run: rustup show

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -30,10 +30,9 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y libudev-dev
-            cargo install elf2uf2-rs
-            elf2uf2-rs target/thumbv6m-none-eabi/release/b1display b1display.uf2
-            elf2uf2-rs target/thumbv6m-none-eabi/release/c1minimal c1minimal.uf2
-            elf2uf2-rs target/thumbv6m-none-eabi/release/ledmatrix ledmatrix.uf2
+            cargo make b1display uf2
+            cargo make c1minimal uf2
+            cargo make ledmatrix uf2
 
       - name: Upload UF2 files
         uses: actions/upload-artifact@v3
@@ -48,9 +47,9 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y llvm
-            llvm-objcopy -O binary target/thumbv6m-none-eabi/release/b1display b1display.bin
-            llvm-objcopy -O binary target/thumbv6m-none-eabi/release/c1minimal c1minimal.bin
-            llvm-objcopy -O binary target/thumbv6m-none-eabi/release/ledmatrix ledmatrix.bin
+            cargo make b1display bin
+            cargo make c1minimal bin
+            cargo make ledmatrix bin
 
       - name: Upload bin files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Setup Rust toolchain
         run: rustup show
 
+      - run: cargo install cargo-make
+
       - run: cargo install flip-link
-      - run: cargo build -p ledmatrix
-      - run: cargo build -p b1display
-      - run: cargo build -p c1minimal
-      - run: cargo build -p ledmatrix --release
-      - run: cargo build -p b1display --release
-      - run: cargo build -p c1minimal --release
+      - run: cargo make --cwd b1display
+      - run: cargo make --cwd c1minimal
+      - run: cargo make --cwd ledmatrix build-release
+      - run: cargo make --cwd b1display build-release
+      - run: cargo make --cwd c1minimal build-release
 
       - name: Convert to UF2 format
         run: |

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,7 +1,19 @@
-name: Firmware CI Checks
+name: Firmware Checks
 
 on:
-  push
+  push:
+    branches:
+      - master
+      - dev-*
+    paths-ignore:
+      - '*.py'
+      - 'inputmodule-control/**'
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - '*.py'
+      - 'inputmodule-control/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -42,9 +42,9 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y libudev-dev
-            cargo make b1display uf2
-            cargo make c1minimal uf2
-            cargo make ledmatrix uf2
+            cargo make --cwd b1display uf2
+            cargo make --cwd c1minimal uf2
+            cargo make --cwd ledmatrix uf2
 
       - name: Upload UF2 files
         uses: actions/upload-artifact@v3
@@ -59,9 +59,9 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y llvm
-            cargo make b1display bin
-            cargo make c1minimal bin
-            cargo make ledmatrix bin
+            cargo make --cwd b1display bin
+            cargo make --cwd c1minimal bin
+            cargo make --cwd ledmatrix bin
 
       - name: Upload bin files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -69,7 +69,7 @@ jobs:
     - run: cargo install cargo-make
 
     - name: Build Windows tool
-      run: cargo make --profile windows --cwd inputmodule-control build-release
+      run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Windows tool can start
       run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help

--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -49,7 +49,7 @@ jobs:
       run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Linux tool can start
-      run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help
+      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW Hid and VIA commandline'
 
     - name: Upload Linux tool
       uses: actions/upload-artifact@v3
@@ -72,7 +72,7 @@ jobs:
       run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Windows tool can start
-      run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help
+      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW Hid and VIA commandline'
 
     - name: Upload Windows App
       uses: actions/upload-artifact@v3

--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -66,7 +66,7 @@ jobs:
       run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Linux tool can start
-      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW Hid and VIA commandline'
+      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW HID and VIA commandline'
 
     - name: Upload Linux tool
       uses: actions/upload-artifact@v3
@@ -89,7 +89,7 @@ jobs:
       run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Windows tool can start
-      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW Hid and VIA commandline'
+      run: cargo make --cwd inputmodule-control run -- --help | grep 'RAW HID and VIA commandline'
 
     - name: Upload Windows App
       uses: actions/upload-artifact@v3

--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -1,6 +1,23 @@
-name: Software CI Checks
+name: Software Checks
+
 on:
   push:
+    branches:
+      - master
+      - dev-*
+    paths-ignore:
+      - 'b1display/**'
+      - 'c1minimal/**'
+      - 'fl16-inputmodules/**'
+      - 'ledmatrix/**'
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - 'b1display/**'
+      - 'c1minimal/**'
+      - 'fl16-inputmodules/**'
+      - 'ledmatrix/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -43,8 +43,10 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup show
 
+    - run: cargo install cargo-make
+
     - name: Build Linux tool
-      run: cargo build --release --target x86_64-unknown-linux-gnu -p inputmodule-control
+      run: cargo make --cwd inputmodule-control build-release
 
     - name: Check if Linux tool can start
       run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help
@@ -64,8 +66,10 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup show
 
+    - run: cargo install cargo-make
+
     - name: Build Windows tool
-      run: cargo build --release --target x86_64-pc-windows-msvc -p inputmodule-control
+      run: cargo make --profile windows --cwd inputmodule-control build-release
 
     - name: Check if Windows tool can start
       run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help

--- a/.github/workflows/traditional-cargo.yml
+++ b/.github/workflows/traditional-cargo.yml
@@ -1,0 +1,89 @@
+# Test builds without cargo-make
+# Not the recommended path, but should make sure it still works
+name: Traditional Cargo Workflow
+
+on:
+  push
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+jobs:
+  firmware:
+    name: Building
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - run: cargo install flip-link
+
+      - run: cargo build -p ledmatrix
+      - run: cargo build -p b1display
+      - run: cargo build -p c1minimal
+
+  linux-software:
+    name: Build Linux
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libudev-dev libasound2-dev
+
+    - name: Setup Rust toolchain
+      run: rustup show
+
+    - name: Build tool
+      run: cargo build --release --target x86_64-unknown-linux-gnu -p inputmodule-control
+
+    - name: Check if tool can start
+      run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help | grep 'RAW Hid and VIA commandline'
+
+  windows-software:
+    name: Build Windows
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Rust toolchain
+      run: rustup show
+
+    - run: cargo install cargo-make
+
+    - name: Build tool
+      run: cargo build --release --target x86_64-pc-windows-msvc -p inputmodule-control
+
+    - name: Check if tool can start
+      run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help | grep 'RAW Hid and VIA commandline'
+
+  lint-format:
+    name: Lint and format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev libasound2-dev
+
+      - name: Setup Rust toolchain
+        run: rustup show
+
+      - name: Firmware clippy
+        run: |
+          cargo clippy -p b1display -- --deny=warnings
+          cargo clippy -p c1minimal -- --deny=warnings
+          cargo clippy -p ledmatrix -- --deny=warnings
+
+      - name: Software clippy
+        run: cargo clippy --target x86_64-unknown-linux-gnu -p inputmodule-control -- -D warnings
+
+      - name: All cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/traditional-cargo.yml
+++ b/.github/workflows/traditional-cargo.yml
@@ -53,7 +53,7 @@ jobs:
       run: cargo build --release --target x86_64-unknown-linux-gnu -p inputmodule-control
 
     - name: Check if tool can start
-      run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help | grep 'RAW Hid and VIA commandline'
+      run: cargo run --release --target x86_64-unknown-linux-gnu -p inputmodule-control -- --help | grep 'RAW HID and VIA commandline'
 
   windows-software:
     name: Build Windows
@@ -70,7 +70,7 @@ jobs:
       run: cargo build --release --target x86_64-pc-windows-msvc -p inputmodule-control
 
     - name: Check if tool can start
-      run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help | grep 'RAW Hid and VIA commandline'
+      run: cargo run --release --target x86_64-pc-windows-msvc -p inputmodule-control -- --help | grep 'RAW HID and VIA commandline'
 
   lint-format:
     name: Lint and format check

--- a/.github/workflows/traditional-cargo.yml
+++ b/.github/workflows/traditional-cargo.yml
@@ -3,7 +3,17 @@
 name: Traditional Cargo Workflow
 
 on:
-  push
+  push:
+    branches:
+      - master
+      - dev-*
+    paths-ignore:
+      - '*.py'
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - '*.py'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,22 @@
+[env]
+TARGET_TRIPLE = "thumbv6m-none-eabi"
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+FEATURES = ""
+
+[tasks.build]
+args = [
+    "build",
+    "@@remove-empty(BUILD_TYPE)",
+    "--target",
+    "${TARGET_TRIPLE}",
+    "--features",
+    "${FEATURES}",
+]
+
+[tasks.build-release]
+clear = true
+env.BUILD_TYPE = "--release"
+run_task = "build"
+
+[tasks.test]
+disabled = true

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ cargo install elf2uf2-rs --locked
 Build:
 
 ```sh
-cargo build -p ledmatrix
-cargo build -p b1display
-cargo build -p c1minimal
+cargo make --cwd ledmatrix
+cargo make --cwd b1display
+cargo make --cwd c1minimal
 ```
 
 Generate the UF2 update file:
@@ -158,7 +158,7 @@ Currently have to specify the build target because it's not possible to specify 
 Tracking issue: https://github.com/rust-lang/cargo/issues/9406
 
 ```
-> cargo build --target x86_64-unknown-linux-gnu -p inputmodule-control
+> cargo make --cwd inputmodule-control
 > cargo run --target x86_64-unknown-linux-gnu -p inputmodule-control
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ Currently have to specify the build target because it's not possible to specify 
 Tracking issue: https://github.com/rust-lang/cargo/issues/9406
 
 ```
+# Build it
 > cargo make --cwd inputmodule-control
-> cargo run --target x86_64-unknown-linux-gnu -p inputmodule-control
+
+# Build and run it, showing the tool version
+> cargo make --cwd inputmodule-control run -- --version
 ```
 
 ### Check the firmware version of the device

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Prepare Rust toolchain (once):
 ```sh
 rustup target install thumbv6m-none-eabi
 cargo install flip-link
-cargo install elf2uf2-rs --locked
 ```
 
 Build:
@@ -145,9 +144,9 @@ cargo make --cwd c1minimal
 Generate the UF2 update file:
 
 ```sh
-elf2uf2-rs target/thumbv6m-none-eabi/debug/ledmatrix ledmatrix.uf2
-elf2uf2-rs target/thumbv6m-none-eabi/debug/b1display b1dipslay.uf2
-elf2uf2-rs target/thumbv6m-none-eabi/debug/c1minimal c1minimal.uf2
+cargo make --cwd ledmatrix uf2
+cargo make --cwd b1display uf2
+cargo make --cwd c1minimal uf2
 ```
 
 ## Building the Application

--- a/b1display/Makefile.toml
+++ b/b1display/Makefile.toml
@@ -1,0 +1,1 @@
+extend = "../Makefile.toml"

--- a/b1display/Makefile.toml
+++ b/b1display/Makefile.toml
@@ -1,1 +1,7 @@
 extend = "../Makefile.toml"
+
+[tasks.uf2]
+command = "elf2uf2-rs"
+args = ["../target/thumbv6m-none-eabi/release/b1display", "../target/thumbv6m-none-eabi/release/b1display.uf2"]
+dependencies = ["build-release"]
+install_crate = "elf2uf2-rs"

--- a/b1display/Makefile.toml
+++ b/b1display/Makefile.toml
@@ -5,3 +5,8 @@ command = "elf2uf2-rs"
 args = ["../target/thumbv6m-none-eabi/release/b1display", "../target/thumbv6m-none-eabi/release/b1display.uf2"]
 dependencies = ["build-release"]
 install_crate = "elf2uf2-rs"
+
+[tasks.bin]
+command = "llvm-objcopy"
+args = ["-Obinary", "../target/thumbv6m-none-eabi/release/b1display", "../target/thumbv6m-none-eabi/release/b1display.bin"]
+dependencies = ["build-release"]

--- a/c1minimal/Makefile.toml
+++ b/c1minimal/Makefile.toml
@@ -1,0 +1,1 @@
+extend = "../Makefile.toml"

--- a/c1minimal/Makefile.toml
+++ b/c1minimal/Makefile.toml
@@ -5,3 +5,8 @@ command = "elf2uf2-rs"
 args = ["../target/thumbv6m-none-eabi/release/c1minimal", "../target/thumbv6m-none-eabi/release/c1minimal.uf2"]
 dependencies = ["build-release"]
 install_crate = "elf2uf2-rs"
+
+[tasks.bin]
+command = "llvm-objcopy"
+args = ["-Obinary", "../target/thumbv6m-none-eabi/release/c1minimal", "../target/thumbv6m-none-eabi/release/c1minimal.bin"]
+dependencies = ["build-release"]

--- a/c1minimal/Makefile.toml
+++ b/c1minimal/Makefile.toml
@@ -1,1 +1,7 @@
 extend = "../Makefile.toml"
+
+[tasks.uf2]
+command = "elf2uf2-rs"
+args = ["../target/thumbv6m-none-eabi/release/c1minimal", "../target/thumbv6m-none-eabi/release/c1minimal.uf2"]
+dependencies = ["build-release"]
+install_crate = "elf2uf2-rs"

--- a/fl16-inputmodules/Makefile.toml
+++ b/fl16-inputmodules/Makefile.toml
@@ -1,0 +1,21 @@
+extend = "../Makefile.toml"
+
+[tasks.build-all]
+run_task = { name = [
+    "build-ledmatrix",
+    "build-b1display",
+    "build-c1minimal",
+], parallel = true }
+
+
+[tasks.build-ledmatrix]
+env.FEATURES = "ledmatrix"
+run_task = "build"
+
+[tasks.build-b1display]
+env.FEATURES = "b1display"
+run_task = "build"
+
+[tasks.build-c1minimal]
+env.FEATURES = "c1minimal"
+run_task = "build"

--- a/fl16-inputmodules/src/lib.rs
+++ b/fl16-inputmodules/src/lib.rs
@@ -1,6 +1,13 @@
 #![allow(clippy::needless_range_loop)]
 #![no_std]
 
+#[cfg(any(
+    all(feature = "ledmatrix", feature = "b1display"),
+    all(feature = "ledmatrix", feature = "c1minimal"),
+    all(feature = "b1display", feature = "c1minimal"),
+))]
+compile_error!("Features \"ledmatrix\", \"b1display\", and \"c1minimal\" are mutually exclusive");
+
 #[cfg(feature = "ledmatrix")]
 pub mod fl16;
 #[cfg(feature = "ledmatrix")]

--- a/inputmodule-control/Makefile.toml
+++ b/inputmodule-control/Makefile.toml
@@ -2,3 +2,7 @@ extend = "../Makefile.toml"
 
 [env]
 TARGET_TRIPLE = "x86_64-unknown-linux-gnu"
+
+# TODO: Automatically detect Windows
+[env.windows]
+TARGET_TRIPLE = "x86_64-pc-windows-msvc"

--- a/inputmodule-control/Makefile.toml
+++ b/inputmodule-control/Makefile.toml
@@ -1,0 +1,4 @@
+extend = "../Makefile.toml"
+
+[env]
+TARGET_TRIPLE = "x86_64-unknown-linux-gnu"

--- a/inputmodule-control/Makefile.toml
+++ b/inputmodule-control/Makefile.toml
@@ -1,8 +1,6 @@
 extend = "../Makefile.toml"
 
+# Since it's a tool, build it for the platform we're running on
 [env]
-TARGET_TRIPLE = "x86_64-unknown-linux-gnu"
+TARGET_TRIPLE = "${CARGO_MAKE_RUST_TARGET_TRIPLE}"
 
-# TODO: Automatically detect Windows
-[env.windows]
-TARGET_TRIPLE = "x86_64-pc-windows-msvc"

--- a/inputmodule-control/Makefile.toml
+++ b/inputmodule-control/Makefile.toml
@@ -4,3 +4,11 @@ extend = "../Makefile.toml"
 [env]
 TARGET_TRIPLE = "${CARGO_MAKE_RUST_TARGET_TRIPLE}"
 
+[tasks.run]
+command = "cargo"
+args = [
+    "run",
+    "--target",
+    "${CARGO_MAKE_RUST_TARGET_TRIPLE}",
+    "${@}",
+]

--- a/ledmatrix/Makefile.toml
+++ b/ledmatrix/Makefile.toml
@@ -1,0 +1,1 @@
+extend = "../Makefile.toml"

--- a/ledmatrix/Makefile.toml
+++ b/ledmatrix/Makefile.toml
@@ -1,1 +1,7 @@
 extend = "../Makefile.toml"
+
+[tasks.uf2]
+command = "elf2uf2-rs"
+args = ["../target/thumbv6m-none-eabi/release/ledmatrix", "../target/thumbv6m-none-eabi/release/ledmatrix.uf2"]
+dependencies = ["build-release"]
+install_crate = "elf2uf2-rs"

--- a/ledmatrix/Makefile.toml
+++ b/ledmatrix/Makefile.toml
@@ -5,3 +5,8 @@ command = "elf2uf2-rs"
 args = ["../target/thumbv6m-none-eabi/release/ledmatrix", "../target/thumbv6m-none-eabi/release/ledmatrix.uf2"]
 dependencies = ["build-release"]
 install_crate = "elf2uf2-rs"
+
+[tasks.bin]
+command = "llvm-objcopy"
+args = ["-Obinary", "../target/thumbv6m-none-eabi/release/ledmatrix", "../target/thumbv6m-none-eabi/release/ledmatrix.bin"]
+dependencies = ["build-release"]


### PR DESCRIPTION
As mentioned in #33, here is a first pass at `cargo make` integration, Running `cargo make` in the workspace root will build every package with the appropriate target (it will also run rustfmt by default). `cargo make` can also be run in individual packages to build just that package. This only scratches the surface of  what the tool can do(e.g. it can also be used to install dependencies like `flip-link`, it can be used as part of your CI, etc. ) 

You will need to [install cargo make](https://github.com/sagiegurari/cargo-make#installation) to make use of the changes.

I also added a a more understandable compiler error if someone attempts to build `fl16-inputmodules` with mutually exclusive features enabled.

