### PR TITLE
ledmatrix: Automatically go to sleep and enable sleep/wake commands

### DIFF
--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -199,14 +199,14 @@ is useful for debugging whether the device is sleeping or not powered.
 
 What can change the sleep state
 
-- Hardware triggers
+- Hardware/OS triggers
   - `SLEEP#` pin
   - USB Suspend
-- Software Triggers
+- Software/Firmware Triggers
   - Sleep/Wake Command via USB Serial
   - Idle timer
 
-Both of the hardware triggers change the sleep state if the transition from one state to another.
+Both of the hardware/OS triggers change the sleep state if the transition from one state to another.
 For example, if USB suspends, the LED matrix turns off. If it resumes, the LEDs come back on.
 Same for the `SLEEP#` pin.
 

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -204,9 +204,12 @@ What can change the sleep state
   - USB Suspend
 - Software Triggers
   - Sleep/Wake Command via USB Serial
+  - Idle timer
 
 Both of the hardware triggers change the sleep state if the transition from one state to another.
 For example, if USB suspends, the LED matrix turns off. If it resumes, the LEDs come back on.
 Same for the `SLEEP#` pin.
 
 The sleep/wake command always changes the state. But it can't be received when USB is suspended.
+
+The idle timer will send the device to sleep after a configured timeout.

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -206,9 +206,11 @@ What can change the sleep state
   - Sleep/Wake or other command via USB Serial
   - Idle timer
 
-Both of the hardware/OS triggers change the sleep state if the transition from one state to another.
+Both of the hardware/OS triggers change the sleep state if they transition from one state to another.
 For example, if USB suspends, the LED matrix turns off. If it resumes, the LEDs come back on.
 Same for the `SLEEP#` pin.
+If either of them indicates sleep, even if they didn'td change state, the module goes to sleep.
+If they're active, they don't influence module state. That way sleep state can be controlled by commands and isn't overridden immediately.
 
 The sleep/wake command always changes the state. But it can't be received when USB is suspended.
 Any other command will also wake up the device.

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -203,7 +203,7 @@ What can change the sleep state
   - `SLEEP#` pin
   - USB Suspend
 - Software/Firmware Triggers
-  - Sleep/Wake Command via USB Serial
+  - Sleep/Wake or other command via USB Serial
   - Idle timer
 
 Both of the hardware/OS triggers change the sleep state if the transition from one state to another.
@@ -211,6 +211,7 @@ For example, if USB suspends, the LED matrix turns off. If it resumes, the LEDs 
 Same for the `SLEEP#` pin.
 
 The sleep/wake command always changes the state. But it can't be received when USB is suspended.
+Any other command will also wake up the device.
 
 The idle timer will send the device to sleep after a configured timeout (default 60 seconds).
 The idle timer is reset once the device wakes up or once it receives a command.

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -184,3 +184,29 @@ run the stop command.
 ```sh
 inputmodule-control led-amtrix --stop-game
 ```
+
+## Sleep Behavior
+
+Currently sleeping means all LEDs and the LED controller are turned off.
+Transitions of sleep state slowly fade the LEDs on or off.
+
+Optionally the firmware can be configured, at build-time, to turn the LEDs
+on/off immediately. Or display "SLEEP" instead of turning the LEDs off, which
+is useful for debugging whether the device is sleeping or not powered.
+
+
+###### Changing Sleep State
+
+What can change the sleep state
+
+- Hardware triggers
+  - `SLEEP#` pin
+  - USB Suspend
+- Software Triggers
+  - Sleep/Wake Command via USB Serial
+
+Both of the hardware triggers change the sleep state if the transition from one state to another.
+For example, if USB suspends, the LED matrix turns off. If it resumes, the LEDs come back on.
+Same for the `SLEEP#` pin.
+
+The sleep/wake command always changes the state. But it can't be received when USB is suspended.

--- a/ledmatrix/README.md
+++ b/ledmatrix/README.md
@@ -212,4 +212,5 @@ Same for the `SLEEP#` pin.
 
 The sleep/wake command always changes the state. But it can't be received when USB is suspended.
 
-The idle timer will send the device to sleep after a configured timeout.
+The idle timer will send the device to sleep after a configured timeout (default 60 seconds).
+The idle timer is reset once the device wakes up or once it receives a command.

--- a/ledmatrix/src/main.rs
+++ b/ledmatrix/src/main.rs
@@ -361,6 +361,7 @@ fn main() -> ! {
                 Ok(count) => {
                     let random = get_random_byte(&rosc);
                     match (parse_command(count, &buf), &state.sleeping) {
+                        // While sleeping no command is handled, except waking up
                         (Some(Command::Sleep(go_sleeping)), _) => {
                             sleeping = go_sleeping;
                             handle_sleep(
@@ -383,7 +384,9 @@ fn main() -> ! {
                             // If there's a very early command, cancel the startup animation
                             startup_percentage = None;
 
-                            // While sleeping no command is handled, except waking up
+                            // Reset sleep timer when interacting with the device
+                            sleep_timer = timer.get_counter().ticks();
+
                             if let Some(response) =
                                 handle_command(&command, &mut state, &mut matrix, random)
                             {

--- a/ledmatrix/src/main.rs
+++ b/ledmatrix/src/main.rs
@@ -372,20 +372,21 @@ fn main() -> ! {
                                 &mut led_enable,
                             );
                         }
-                        (Some(c @ Command::BootloaderReset), _)
-                        | (Some(c @ Command::IsSleeping), _) => {
-                            if let Some(response) =
-                                handle_command(&c, &mut state, &mut matrix, random)
-                            {
-                                let _ = serial.write(&response);
-                            };
-                        }
-                        (Some(command), SleepState::Awake) => {
+                        (Some(command), _) => {
                             // If there's a very early command, cancel the startup animation
                             startup_percentage = None;
 
                             // Reset sleep timer when interacting with the device
                             sleep_timer = timer.get_counter().ticks();
+                            // If already sleeping, wake up
+                            sleeping = false;
+                            handle_sleep(
+                                sleeping,
+                                &mut state,
+                                &mut matrix,
+                                &mut delay,
+                                &mut led_enable,
+                            );
 
                             if let Some(response) =
                                 handle_command(&command, &mut state, &mut matrix, random)
@@ -401,6 +402,7 @@ fn main() -> ! {
                                 buf[0], buf[1], buf[2], buf[3]
                             )
                             .unwrap();
+                            // let _ = serial.write(text.as_bytes());
                             fill_grid_pixels(&state, &mut matrix);
                         }
                         _ => {}

--- a/ledmatrix_control.py
+++ b/ledmatrix_control.py
@@ -1108,9 +1108,8 @@ def gui(devices):
             sg.Button("Stop", k='-STOP-EQ-')
         ],
 
-        # Recent hardware sleeps based on sleep pin, not command
-        #[sg.Text("Sleep")],
-        #[sg.Button("Sleep"), sg.Button("Wake")],
+        [sg.Text("Sleep")],
+        [sg.Button("Sleep"), sg.Button("Wake")],
         # [sg.Button("Panic")]
     ]
     window = sg.Window("LED Matrix Control", layout)


### PR DESCRIPTION
Change sleep only if state changed or should sleep
This means the software sleep control will work again. Hardware sleep
control won't override it.

See README for detailed description of new sleep behavior.