### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,31 @@ members = [
 # target. But we set the default target to thumbv6m-none-eabi
 default-members = ["fl16-inputmodules"]
 
-#[patch.'https://github.com/rp-rs/rp-hal.git']
-#rp2040-hal = { path = "./rp2040-hal" }
-#
-#[patch.crates-io]
-#rp2040-hal = { path = "./rp2040-hal" }
+[workspace.dependencies]
+cortex-m = "0.7"
+cortex-m-rt = "0.7.3"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+rp2040-panic-usb-boot = "0.5.0"
+rp2040-hal = { version = "0.8", features = ["rt", "critical-section-impl"] }
+rp2040-boot2 = "0.3"
+defmt = "0.3"
+defmt-rtt = "0.4"
+# USB Serial
+usb-device = "0.2.9"
+heapless = "0.7.16"
+usbd-serial = "0.1.1"
+usbd-hid = "0.6.1"
+fugit = "0.3.7"
+# LED Matrix
+is31fl3741 = { git = "https://github.com/JohnAZoidberg/is31fl3741", branch = "merged" }
+# B1 Display
+st7306 = { git = "https://github.com/FrameworkComputer/st7306-rs", branch = "update-deps" }
+embedded-graphics = "0.8"
+tinybmp = "0.5.0"
+# C1 Minimal
+smart-leds = "0.3.0"
+ws2812-pio = "0.6.0"
 
 # cargo build/run
 [profile.dev]

--- a/b1display/Cargo.toml
+++ b/b1display/Cargo.toml
@@ -4,31 +4,30 @@ name = "b1display"
 version = "0.1.5"
 
 [dependencies]
-cortex-m = "0.7"
-cortex-m-rt = "0.7.3"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+cortex-m.workspace = true
+cortex-m-rt.workspace = true
+embedded-hal.workspace = true
 
-defmt = "0.3"
-defmt-rtt = "0.4"
+defmt.workspace = true
+defmt-rtt.workspace = true
 
-#panic-probe = { version = "0.3", features = ["print-defmt"] }
-rp2040-panic-usb-boot = "0.5.0"
+#panic-probe.workspace = true
+rp2040-panic-usb-boot.workspace = true
 
 # Not using an external BSP, we've got the Framework Laptop 16 BSPs locally in this crate
-rp2040-hal = { version="0.8", features=["rt", "critical-section-impl"] }
-rp2040-boot2 = "0.3"
+rp2040-hal.workspace = true
+rp2040-boot2.workspace = true
 
 # USB Serial
-usb-device= "0.2.9"
+usb-device.workspace = true
+heapless.workspace = true
+usbd-serial.workspace = true
+usbd-hid.workspace = true
+fugit.workspace = true
 
-heapless = "0.7.16"
-usbd-serial = "0.1.1"
-usbd-hid = "0.6.1"
-fugit = "0.3.7"
-
-st7306 = { git = "https://github.com/FrameworkComputer/st7306-rs", branch = "update-deps" }
-embedded-graphics = "0.8"
-tinybmp = "0.5.0"
+st7306.workspace = true
+embedded-graphics.workspace = true
+tinybmp.workspace = true
 
 [dependencies.fl16-inputmodules]
 path = "../fl16-inputmodules"

--- a/c1minimal/Cargo.toml
+++ b/c1minimal/Cargo.toml
@@ -4,30 +4,30 @@ name = "c1minimal"
 version = "0.1.5"
 
 [dependencies]
-cortex-m = "0.7"
-cortex-m-rt = "0.7.3"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+cortex-m.workspace = true
+cortex-m-rt.workspace = true
+embedded-hal.workspace = true
 
-defmt = "0.3"
-defmt-rtt = "0.4"
+defmt.workspace = true
+defmt-rtt.workspace = true
 
-#panic-probe = { version = "0.3", features = ["print-defmt"] }
-rp2040-panic-usb-boot = "0.5.0"
+#panic-probe.workspace = true
+rp2040-panic-usb-boot.workspace = true
 
-# Not using an external BSP, we've got the Framework Laptop BSPs locally in this crate
-rp2040-hal = { version="0.8", features=["rt", "critical-section-impl"] }
-rp2040-boot2 = "0.3"
+# Not using an external BSP, we've got the Framework Laptop 16 BSPs locally in this crate
+rp2040-hal.workspace = true
+rp2040-boot2.workspace = true
 
 # USB Serial
-usb-device= "0.2.9"
+usb-device.workspace = true
+heapless.workspace = true
+usbd-serial.workspace = true
+usbd-hid.workspace = true
+fugit.workspace = true
 
-heapless = "0.7.16"
-usbd-serial = "0.1.1"
-usbd-hid = "0.6.1"
-fugit = "0.3.7"
-
-smart-leds = "0.3.0"
-ws2812-pio = "0.6.0"
+# C1 Minimal
+smart-leds.workspace = true
+ws2812-pio.workspace = true
 
 [dependencies.fl16-inputmodules]
 path = "../fl16-inputmodules"

--- a/fl16-inputmodules/Cargo.toml
+++ b/fl16-inputmodules/Cargo.toml
@@ -5,42 +5,42 @@ version = "0.1.5"
 
 [dependencies]
 crc = "3.0"
-cortex-m = "0.7"
-cortex-m-rt = "0.7.3"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+cortex-m.workspace = true
+cortex-m-rt.workspace = true
+embedded-hal.workspace = true
 
-defmt = "0.3"
-defmt-rtt = "0.4"
+defmt.workspace = true
+defmt-rtt.workspace = true
 
-#panic-probe = { version = "0.3", features = ["print-defmt"] }
-rp2040-panic-usb-boot = "0.5.0"
+#panic-probe.workspace = true
+rp2040-panic-usb-boot.workspace = true
 
 # Not using an external BSP, we've got the Framework Laptop 16 BSPs locally in this crate
-rp2040-hal = { version = "0.8", features = ["rt", "critical-section-impl"] }
-rp2040-boot2 = "0.3"
+rp2040-hal.workspace = true
+rp2040-boot2.workspace = true
 
 # USB Serial
-usb-device = "0.2.9"
+usb-device.workspace = true
+heapless.workspace = true
+usbd-serial.workspace = true
+usbd-hid.workspace = true
+fugit.workspace = true
 
-heapless = "0.7.16"
-usbd-serial = "0.1.1"
-usbd-hid = "0.6.1"
-fugit = "0.3.7"
 num = { version = "0.4", default-features = false }
 num-derive = "0.3"
 num-traits = { version = "0.2", default-features = false }
 
 # LED Matrix
-is31fl3741 = { git = "https://github.com/JohnAZoidberg/is31fl3741", branch = "merged", optional = true }
+is31fl3741 = { workspace = true, optional = true }
 
 # B1 Display
-st7306 = { git = "https://github.com/FrameworkComputer/st7306-rs", branch = "update-deps", optional = true }
-embedded-graphics = { version = "0.8", optional = true }
-tinybmp = { version = "0.5.0", optional = true }
+st7306 = { workspace = true, optional = true }
+embedded-graphics = { workspace = true, optional = true }
+tinybmp = { workspace = true, optional = true }
 
 # C1 Minimal
-smart-leds = { version = "0.3.0", optional = true }
-ws2812-pio = { version = "0.6.0", optional = true }
+smart-leds = { workspace = true, optional = true }
+ws2812-pio = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/ledmatrix/Cargo.toml
+++ b/ledmatrix/Cargo.toml
@@ -4,29 +4,28 @@ name = "ledmatrix"
 version = "0.1.5"
 
 [dependencies]
-cortex-m = "0.7"
-cortex-m-rt = "0.7.3"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
+cortex-m.workspace = true
+cortex-m-rt.workspace = true
+embedded-hal.workspace = true
 
-defmt = "0.3"
-defmt-rtt = "0.4"
+defmt.workspace = true
+defmt-rtt.workspace = true
 
-#panic-probe = { version = "0.3", features = ["print-defmt"] }
-rp2040-panic-usb-boot = "0.5.0"
+#panic-probe.workspace = true
+rp2040-panic-usb-boot.workspace = true
 
 # Not using an external BSP, we've got the Framework Laptop 16 BSPs locally in this crate
-rp2040-hal = { version = "0.8", features = ["rt", "critical-section-impl"] }
-rp2040-boot2 = "0.3"
+rp2040-hal.workspace = true
+rp2040-boot2.workspace = true
 
 # USB Serial
-usb-device = "0.2.9"
+usb-device.workspace = true
+heapless.workspace = true
+usbd-serial.workspace = true
+usbd-hid.workspace = true
+fugit.workspace = true
 
-heapless = "0.7.16"
-usbd-serial = "0.1.1"
-usbd-hid = "0.6.1"
-fugit = "0.3.7"
-
-is31fl3741 = { git = "https://github.com/JohnAZoidberg/is31fl3741", branch = "merged" }
+is31fl3741.workspace = true
 
 [dependencies.fl16-inputmodules]
 path = "../fl16-inputmodules"


### PR DESCRIPTION
Ensures all workspace members use the exact same versions of everything. No need to update them in every one of them!