### PR TITLE
Tweak build options for faster tool build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,55 +45,27 @@ tinybmp = "0.5.0"
 smart-leds = "0.3.0"
 ws2812-pio = "0.6.0"
 
-# cargo build/run
-[profile.dev]
+[profile.dev.package.ledmatrix]
 codegen-units = 1
-debug = 2
-debug-assertions = true
-incremental = false
+incremental = true
 # To allow single-stepping through code use 0. Will cause timing issues, though
 opt-level = 3
-overflow-checks = true
 
-# cargo build/run --release
+[profile.dev.package.c1minimal]
+codegen-units = 1
+incremental = true
+# To allow single-stepping through code use 0. Will cause timing issues, though
+opt-level = 3
+
+[profile.dev.package.b1display]
+codegen-units = 1
+incremental = true
+# To allow single-stepping through code use 0. Will cause timing issues, though
+opt-level = 3
+
+# Faster and smaller code but much slower to compile.
+# Increase in rebuild time from <1s to 20s
 [profile.release]
 codegen-units = 1
 debug = 2
-debug-assertions = false
-incremental = false
 lto = 'fat'
-opt-level = 3
-overflow-checks = false
-
-# do not optimize proc-macro crates = faster builds from scratch
-[profile.dev.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false
-
-[profile.release.build-override]
-codegen-units = 8
-debug = false
-debug-assertions = false
-opt-level = 0
-overflow-checks = false
-
-# cargo test
-[profile.test]
-codegen-units = 1
-debug = 2
-debug-assertions = true
-incremental = false
-opt-level = 3
-overflow-checks = true
-
-# cargo test --release
-[profile.bench]
-codegen-units = 1
-debug = 2
-debug-assertions = false
-incremental = false
-lto = 'fat'
-opt-level = 3


### PR DESCRIPTION
Previously building inputmodule-control would be as slow as 20s even with no code change. Now it takes just less than 1s.

- Remove all options that are default - no need to specify them again.
- Keep the release options the same (Still slow tool build but not as important)
- Apply the dev options only to the firmware, not tool

Fixes #19