### PR TITLE
ledmatrix: gamma correction for smoother brightness ramps

### DIFF
--- a/fl16-inputmodules/build.rs
+++ b/fl16-inputmodules/build.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let gamma_path = Path::new(&out_dir).join("gamma.rs");
+    let mut f = File::create(gamma_path).unwrap();
+
+    // Determined empirically for a PVT panel. May need to become conditional
+    // on features, TBD.
+    const GAMMA: f32 = 3.2;
+
+    let corrected: [f32; 256] =
+        std::array::from_fn(|i| f32::powf((i as f32) / 255., GAMMA) * 255. + 0.5);
+
+    writeln!(f, "const GAMMA: [u8; 256] = [").unwrap();
+
+    const LINE_LEN: usize = 8;
+    for line in corrected.chunks(LINE_LEN) {
+        write!(f, "   ").unwrap();
+        for element in line {
+            write!(f, " {:>3},", *element as u8).unwrap();
+        }
+        writeln!(f).unwrap();
+    }
+    writeln!(f, "];").unwrap();
+}

--- a/fl16-inputmodules/src/patterns.rs
+++ b/fl16-inputmodules/src/patterns.rs
@@ -313,7 +313,8 @@ pub fn double_gradient() -> Grid {
 pub fn _fill_grid(grid: &Grid, matrix: &mut Foo) {
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
-            matrix.device.pixel(x as u8, y as u8, grid.0[x][y]).unwrap();
+            let p = gamma::correct(grid.0[x][y]);
+            matrix.device.pixel(x as u8, y as u8, p).unwrap();
         }
     }
 }
@@ -330,9 +331,11 @@ pub fn fill_grid_pixels(state: &LedmatrixState, matrix: &mut Foo) {
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
             let (register, page) = (matrix.device.calc_pixel)(x as u8, y as u8);
-            brightnesses[(page as usize) * 0xB4 + (register as usize)] =
+            let uncorrected =
                 ((state.grid.0[x][y] as u64) * (state.brightness as u64)
                     / (BRIGHTNESS_LEVELS as u64)) as u8;
+            brightnesses[(page as usize) * 0xB4 + (register as usize)] =
+                gamma::correct(uncorrected);
         }
     }
     matrix.device.fill_matrix(&brightnesses).unwrap();
@@ -386,4 +389,12 @@ pub fn every_nth_col(n: usize) -> Grid {
     }
 
     grid
+}
+
+pub mod gamma {
+    pub const fn correct(value: u8) -> u8 {
+        GAMMA[value as usize]
+    }
+
+    include!(concat!(env!("OUT_DIR"), "/gamma.rs"));
 }

--- a/ledmatrix/src/main.rs
+++ b/ledmatrix/src/main.rs
@@ -242,7 +242,7 @@ fn main() -> ! {
         grid: percentage(0),
         col_buffer: Grid::default(),
         animate: false,
-        brightness: 51, // Default to 51/255 = 20% brightness
+        brightness: 150,
         sleeping: SleepState::Awake,
         game: None,
         animation_period: 31_250, // 31,250 us = 32 FPS


### PR DESCRIPTION
The brightness values sent to the LED controller actually control a PWM
duty cycle. LEDs emit light roughly in proportion to the PWM duty cycle,
but human vision perceives brightness on an exponential curve --
generally it takes 2x the physical luminous flux for the eye to perceive
something as one step brighter.
    
As a result, brightness ramps (like the one generated by
--all-brightnesses) were rapidly brightening to what appeared to be max,
and then flattening.
    
This change adds [gamma correction](https://en.wikipedia.org/wiki/Gamma_correction), which maps the linear input
brightness values to a non-linear function of PWM duty cycles, causing
the ramp to look far more ramp-y.
    
The gamma value I've chosen here is arguably a preference, I messed with
output on a PVT panel until I found something that looked approximately
right.

Photo of a panel with the firmware from `main` (left) vs this change (right):
![PXL_20240320_171617774](https://github.com/FrameworkComputer/inputmodule-rs/assets/45247/27811139-fe96-4a0d-b097-10e8055d69b4)
