### PR TITLE
inputmodule-control: Ignore /dev/tty. on macOS

### DIFF
--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -90,6 +90,12 @@ fn match_serialdevs(
         // Find all supported Framework devices
         for p in ports {
             if let SerialPortType::UsbPort(usbinfo) = &p.port_type {
+                // macOS creates a /dev/cu.* and /dev/tty.* device.
+                // The latter can only be used for reading, not writing, so we have to ignore it.
+                #[cfg(target_os = "macos")]
+                if !p.port_name.starts_with("/dev/tty.") {
+                    continue;
+                }
                 if usbinfo.vid == FRAMEWORK_VID && pids.contains(&usbinfo.pid) {
                     compatible_devs.push(p.port_name.clone());
                 }


### PR DESCRIPTION
Add rustup, cargo-make and elf2uf2-rs as dependencies to ensure that a
user with no prior rust installation can build the firmware.