### PR TITLE
inputmodule-control: Limit FPS to 1000

### DIFF
--- a/fl16-inputmodules/src/control.rs
+++ b/fl16-inputmodules/src/control.rs
@@ -202,7 +202,9 @@ pub enum Command {
     GetFps,
     SetPowerMode(u8),
     GetPowerMode,
+    /// Set the animation period in milliseconds
     SetAnimationPeriod(u16),
+    /// Get the animation period in milliseconds
     GetAnimationPeriod,
     #[cfg(feature = "ledmatrix")]
     SetPwmFreq(PwmFreqArg),
@@ -249,6 +251,7 @@ pub struct B1DIsplayState {
     pub screensaver: Option<ScreenSaverState>,
     pub power_mode: PowerMode,
     pub fps_config: FpsConfig,
+    /// Animation period in microseconds
     pub animation_period: u64,
 }
 

--- a/fl16-inputmodules/src/matrix.rs
+++ b/fl16-inputmodules/src/matrix.rs
@@ -37,6 +37,7 @@ pub struct LedmatrixState {
     pub sleeping: SleepState,
     /// State of the current game, if any
     pub game: Option<GameState>,
+    /// Animation perios in microseconds
     pub animation_period: u64,
     /// Current LED PWM frequency
     pub pwm_freq: PwmFreqArg,

--- a/inputmodule-control/src/inputmodule.rs
+++ b/inputmodule-control/src/inputmodule.rs
@@ -1000,7 +1000,13 @@ fn animation_fps_cmd(serialdev: &str, arg: Option<u16>) {
         .expect("Failed to open port");
 
     if let Some(fps) = arg {
-        let period = (1000 / fps).to_le_bytes();
+        const MS: u16 = 1000;
+        if fps < MS {
+            // It would need to set the animation period lower than 1ms
+            println!("Unable to set FPS over 1000");
+            return;
+        }
+        let period = (MS / fps).to_le_bytes();
         simple_cmd_port(&mut port, Command::AnimationPeriod, &[period[0], period[1]]);
     } else {
         simple_cmd_port(&mut port, Command::AnimationPeriod, &[]);


### PR DESCRIPTION
Otherwise the division in the CLI results in 0 and tells the firmware to set the animation frequency to 0ms.

Fixes #113