### PR TITLE
Feat: only certain commands wake up the device

### DIFF
--- a/fl16-inputmodules/src/control.rs
+++ b/fl16-inputmodules/src/control.rs
@@ -214,6 +214,40 @@ pub enum Command {
     _Unknown,
 }
 
+impl Command {
+    pub fn should_wake(&self) -> bool {
+        match self {
+            Self::SetBrightness(_)
+            | Self::Pattern(_)
+            | Self::Percentage(_)
+            | Self::SetAnimate(_)
+            | Self::Draw(_)
+            | Self::DrawGreyColBuffer
+            | Self::StartGame(_)
+            | Self::GameControl(_)
+            | Self::DisplayOn(_)
+            | Self::InvertScreen(_)
+            | Self::SetPixelColumn(_, _)
+            | Self::FlushFramebuffer
+            | Self::ScreenSaver(_)
+            | Self::SetFps(_)
+            | Self::SetPowerMode(_)
+            | Self::SetDebugMode(_) => true,
+
+            #[cfg(feature = "ledmatrix")]
+            Self::Draw(_) | Self::SetPwmFreq(_) => true,
+
+            #[cfg(feature = "c1minimal")]
+            Self::SetColor(_) => true,
+
+            #[cfg(feature = "b1display")]
+            Self::SetText(_) => true,
+
+            _ => false,
+        }
+    }
+}
+
 #[cfg(any(feature = "c1minimal", feature = "b1display"))]
 #[derive(Clone)]
 pub enum SimpleSleepState {

--- a/ledmatrix/src/main.rs
+++ b/ledmatrix/src/main.rs
@@ -449,9 +449,10 @@ fn main() -> ! {
                                     true,
                                     SleepReason::Command,
                                 );
-                            } else {
+                            } else if command.should_wake() {
                                 // If already sleeping, wake up.
-                                // This means every command will wake the device up.
+                                // Only certain commnads should wake the device - for example
+                                // StageGreyCol shouldn't
                                 // Much more convenient than having to send the wakeup commmand.
                                 sleep_reason = None;
                             }
@@ -493,8 +494,9 @@ fn main() -> ! {
                             )
                             .unwrap();
                             // let _ = serial.write(text.as_bytes());
-
-                            fill_grid_pixels(&state, &mut matrix);
+                            if command.should_wake() {
+                                fill_grid_pixels(&state, &mut matrix);
+                            }
                         }
                         (None, _) => {}
                     }


### PR DESCRIPTION
Fix of #107 .

Previously all commands woke up the device, though that wasn't always wanted. Now only certain commands, that change brightness/grid wake up the device.

edit: also fix of #131 , #124 , partial fix of #108 