### PR TITLE
README: Install tools with --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Prepare Rust toolchain (once):
 
 ```sh
 rustup target install thumbv6m-none-eabi
-cargo install flip-link
-cargo install cargo-make
-cargo install elf2uf2-rs
+cargo install flip-link --locked
+cargo install cargo-make --locked
+cargo install elf2uf2-rs --locked
 ```
 
 Build:
@@ -161,7 +161,7 @@ Tracking issue: https://github.com/rust-lang/cargo/issues/9406
 
 ```sh
 # Install cargo-make to help build it
-cargo install cargo-make
+cargo install cargo-make --locked
 
 # Build it
 > cargo make --cwd inputmodule-control


### PR DESCRIPTION
Fixes: https://github.com/FrameworkComputer/inputmodule-rs/issues/133
See: https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile