### PR TITLE
Sleep related fixes

### DIFF
--- a/ledmatrix/src/main.rs
+++ b/ledmatrix/src/main.rs
@@ -437,8 +437,14 @@ fn main() -> ! {
                     match (parse_command(count, &buf), &state.sleeping) {
                         // Handle bootloader command without any delay
                         // No need, it'll reset the device anyways
-                        (Some(c @ Command::BootloaderReset), _) => {
-                            handle_command(&c, &mut state, &mut matrix, random);
+                        (Some(c @ Command::BootloaderReset), _)
+                        // Additionally, there's no point to IsSleeping if it needs to wake up first
+                        | (Some(c @ Command::IsSleeping), _) => {
+                            if let Some(response) =
+                                handle_command(&c, &mut state, &mut matrix, random)
+                            {
+                                let _ = serial.write(&response);
+                            };
                         }
                         (Some(command), _) => {
                             if let Command::Sleep(go_sleeping) = command {


### PR DESCRIPTION
I fixed a bug in the led matrix where it would have to wake up before reporting its sleep state, resulting in the state always being false.
Additionally, the inputmodule-control cli didn't know how to handle sleeping devices so it now attempts to wake the device up first before running commands relating to reading where the device doesn't respond while asleep.